### PR TITLE
removed read-slice function and memory optmizations

### DIFF
--- a/contracts/clarity-bitcoin.clar
+++ b/contracts/clarity-bitcoin.clar
@@ -156,7 +156,7 @@
           (new-ctx (get ctx parsed-num-txins)))
      (if (> num-txins u8)
          (err ERR-TOO-MANY-TXINS)
-         (fold read-next-txin (list true true true true true true true true) (ok { ctx: new-ctx, remaining: num-txins, txins: (list)})))))
+         (fold read-next-txin (unwrap-panic (slice? (list true true true true true true true true) u0 num-txins)) (ok { ctx: new-ctx, remaining: num-txins, txins: (list)})))))
 
 ;; Read the next transaction output, and update the index in ctx to point to the next output.
 ;; Returns (ok { ... }) on success
@@ -200,7 +200,7 @@
           (new-ctx (get ctx parsed-num-txouts)))
      (if (> num-txouts u8)
          (err ERR-TOO-MANY-TXOUTS)
-         (fold read-next-txout (list true true true true true true true true) (ok { ctx: new-ctx, remaining: num-txouts, txouts: (list)})))))
+         (fold read-next-txout (unwrap-panic (slice? (list true true true true true true true true) u0 num-txouts)) (ok { ctx: new-ctx, remaining: num-txouts, txouts: (list)})))))
 
 ;; Helper functions for smart contract that want to use information of a Bitcoin transaction
 ;;

--- a/contracts/clarity-bitcoin.clar
+++ b/contracts/clarity-bitcoin.clar
@@ -6,21 +6,13 @@
 (define-constant ERR-BAD-HEADER u5)
 (define-constant ERR-PROOF-TOO-SHORT u6)
 
-;; Top-level function to read a slice of a given size from a given (buff 1024), starting at a given offset.
-;; Returns (ok (buff 1024)) on success, and it contains "buff[offset..(offset+size)]"
-;; Returns (err ERR-OUT-OF-BOUNDS) if the slice offset and/or size would copy a range of bytes outside the given buffer.
-(define-read-only (read-slice (data (buff 1024)) (offset uint) (size uint))
-    (ok
-        (unwrap! (slice? data offset (+ offset size)) (err ERR-OUT-OF-BOUNDS))))
-
 ;; Reads the next two bytes from txbuff as a little-endian 16-bit integer, and updates the index.
 ;; Returns (ok { uint16: uint, ctx: { txbuff: (buff 1024), index: uint } }) on success.
 ;; Returns (err ERR-OUT-OF-BOUNDS) if we read past the end of txbuff
 (define-read-only (read-uint16 (ctx { txbuff: (buff 1024), index: uint}))
     (let ((data (get txbuff ctx))
-          (base (get index ctx))
-          (ret (buff-to-uint-le (unwrap! (as-max-len? (unwrap! (slice? data base (+ base u2)) (err ERR-OUT-OF-BOUNDS)) u2) (err ERR-OUT-OF-BOUNDS)))))
-        (ok {uint16: ret,
+          (base (get index ctx)))
+        (ok {uint16: (buff-to-uint-le (unwrap-panic (as-max-len? (unwrap! (slice? data base (+ base u2)) (err ERR-OUT-OF-BOUNDS)) u2))),
              ctx: { txbuff: data, index: (+ u2 base)}})))
 
 ;; Reads the next four bytes from txbuff as a little-endian 32-bit integer, and updates the index.
@@ -28,9 +20,8 @@
 ;; Returns (err ERR-OUT-OF-BOUNDS) if we read past the end of txbuff
 (define-read-only (read-uint32 (ctx { txbuff: (buff 1024), index: uint}))
     (let ((data (get txbuff ctx))
-          (base (get index ctx))
-          (ret (buff-to-uint-le (unwrap! (as-max-len? (unwrap! (slice? data base (+ base u4)) (err ERR-OUT-OF-BOUNDS)) u4) (err ERR-OUT-OF-BOUNDS)))))
-        (ok {uint32: ret,
+          (base (get index ctx)))
+        (ok {uint32: (buff-to-uint-le (unwrap-panic (as-max-len? (unwrap! (slice? data base (+ base u4)) (err ERR-OUT-OF-BOUNDS)) u4))),
              ctx: { txbuff: data, index: (+ u4 base)}})))
 
 ;; Reads the next eight bytes from txbuff as a little-endian 64-bit integer, and updates the index.
@@ -38,9 +29,8 @@
 ;; Returns (err ERR-OUT-OF-BOUNDS) if we read past the end of txbuff
 (define-read-only (read-uint64 (ctx { txbuff: (buff 1024), index: uint}))
     (let ((data (get txbuff ctx))
-          (base (get index ctx))
-          (ret (buff-to-uint-le (unwrap! (as-max-len? (unwrap! (slice? data base (+ base u8)) (err ERR-OUT-OF-BOUNDS)) u8) (err ERR-OUT-OF-BOUNDS)))))
-        (ok {uint64: ret,
+          (base (get index ctx)))
+        (ok {uint64: (buff-to-uint-le (unwrap-panic (as-max-len? (unwrap! (slice? data base (+ base u8)) (err ERR-OUT-OF-BOUNDS)) u8))),
              ctx: { txbuff: data, index: (+ u8 base)}})))
 
 ;; Reads the next varint from txbuff, and updates the index.
@@ -74,16 +64,16 @@
 ;; Returns (err ERR-OUT-OF-BOUNDS) if we read past the end of txbuff.
 (define-read-only (read-varslice (old-ctx { txbuff: (buff 1024), index: uint}))
     (let ((parsed (try! (read-varint old-ctx)))
-          (slice-len (get varint parsed))
           (ctx (get ctx parsed))
-          (slice (try! (read-slice (get txbuff ctx) (get index ctx) slice-len))))
-     (ok {varslice: slice,
-          ctx: { txbuff: (get txbuff ctx), index: (+ (len slice) (get index ctx))}})))
+          (slice-start (get index ctx))
+          (target-index (+ slice-start (get varint parsed)))
+          (txbuff (get txbuff ctx)))
+     (ok {varslice: (unwrap! (slice? txbuff slice-start target-index) (err ERR-OUT-OF-BOUNDS)),
+          ctx: { txbuff: txbuff, index: target-index}})))
 
 ;; Generate a permutation of a given 32-byte buffer, appending the element at target-index to hash-output.
 ;; The target-index decides which index in hash-input gets appended to hash-output.
 (define-read-only (inner-reverse (target-index uint) (hash-input (buff 32)))
-    (let ((temp-var (unwrap-panic (element-at? hash-input  target-index))))
     (unwrap-panic 
         (replace-at? 
             (unwrap-panic 
@@ -92,7 +82,7 @@
                     target-index 
                     (unwrap-panic (element-at? hash-input (- u31 target-index)))))
             (- u31 target-index) 
-            temp-var))))
+            (unwrap-panic (element-at? hash-input  target-index)))))
 
 ;; Reverse the byte order of a 32-byte buffer.  Returns the (buff 32).
 (define-read-only (reverse-buff32 (input (buff 32)))
@@ -104,12 +94,15 @@
 ;; Returns (ok { hashslice: (buff 32), ctx: { txbuff: (buff 1024), index: uint } }) on success, and updates the index.
 ;; Returns (err ERR-OUT-OF-BOUNDS) if we read past the end of txbuff.
 (define-read-only (read-hashslice (old-ctx { txbuff: (buff 1024), index: uint}))
-    (let ((hash-le (unwrap-panic
-                      (as-max-len? (try!
-                                      (read-slice (get txbuff old-ctx) (get index old-ctx) u32))
+    (let ((slice-start (get index old-ctx))
+          (target-index (+ u32 slice-start))
+          (txbuff (get txbuff old-ctx))
+          (hash-le (unwrap-panic
+                      (as-max-len? (unwrap!
+                                      (slice? txbuff slice-start target-index) (err ERR-OUT-OF-BOUNDS))
                        u32))))
      (ok {hashslice: (reverse-buff32 hash-le),
-          ctx: { txbuff: (get txbuff old-ctx), index: (+ u32 (get index old-ctx))}})))
+          ctx: { txbuff: txbuff, index: target-index}})))
 
 ;; Inner fold method to read the next tx input from txbuff.
 ;; The index in ctx will be updated to point to the next tx input if all goes well (or to the start of the outputs)
@@ -122,8 +115,7 @@
                                                         remaining: uint,
                                                         txins: (list 8 {outpoint: {
                                                                                    hash: (buff 32),
-                                                                                   index: uint}
-                                                                        ,
+                                                                                   index: uint},
                                                                         scriptSig: (buff 256),      ;; just big enough to hold a 2-of-3 multisig script
                                                                         sequence: uint})}
                                               uint)))
@@ -144,8 +136,7 @@
                                   (append (get txins state)
                                       {   outpoint: {
                                                      hash: (get hashslice parsed-hash),
-                                                     index: (get uint32 parsed-index)}
-                                          ,
+                                                     index: (get uint32 parsed-index) },
                                           scriptSig: (unwrap! (as-max-len? (get varslice parsed-scriptSig) u256) (err ERR-VARSLICE-TOO-LONG)),
                                           sequence: (get uint32 parsed-sequence)})
                                u8)
@@ -258,17 +249,14 @@
 ;;      nbits: uint,                    ;; compact block difficulty representation
 ;;      nonce: uint                     ;; PoW solution
 ;; })
-;; Returns (err ERR-BAD-HEADER) if the header buffer isn't actually 80 bytes long.
 (define-read-only (parse-block-header (headerbuff (buff 80)))
-    (let ((ctx { txbuff: (unwrap! (as-max-len? headerbuff u1024) (err ERR-BAD-HEADER)), index: u0})
-
-        ;; none of these should fail, since they're all fixed-length fields whose lengths sum to 80
-          (parsed-version (unwrap-panic (read-uint32 ctx)))
-          (parsed-parent-hash (unwrap-panic (read-hashslice (get ctx parsed-version))))
-          (parsed-merkle-root (unwrap-panic (read-hashslice (get ctx parsed-parent-hash))))
-          (parsed-timestamp (unwrap-panic (read-uint32 (get ctx parsed-merkle-root))))
-          (parsed-nbits (unwrap-panic (read-uint32 (get ctx parsed-timestamp))))
-          (parsed-nonce (unwrap-panic (read-uint32 (get ctx parsed-nbits)))))
+    (let ((ctx { txbuff: headerbuff, index: u0})
+          (parsed-version (try! (read-uint32 ctx)))
+          (parsed-parent-hash (try! (read-hashslice (get ctx parsed-version))))
+          (parsed-merkle-root (try! (read-hashslice (get ctx parsed-parent-hash))))
+          (parsed-timestamp (try! (read-uint32 (get ctx parsed-merkle-root))))
+          (parsed-nbits (try! (read-uint32 (get ctx parsed-timestamp))))
+          (parsed-nonce (try! (read-uint32 (get ctx parsed-nbits)))))
      (ok {version: (get uint32 parsed-version),
           parent: (get hashslice parsed-parent-hash),
           merkle-root: (get hashslice parsed-merkle-root),
@@ -283,22 +271,20 @@
 ;; Returns true if so; false if not.
 (define-read-only (verify-block-header (headerbuff (buff 80)) (expected-block-height uint))
     (match (get-bc-h-hash expected-block-height)
-        bhh (is-eq bhh (reverse-buff32 (sha256 (sha256 headerbuff))))
+        bhh (is-eq bhh (reverse-buff32 (SHA-256d headerbuff)))
         false))
 
-;; Get the txid of a transaction, but little-endian.
-;; This is the reverse of what you see on block explorers.
-(define-read-only (get-reversed-txid (tx (buff 1024)))
-    (sha256 (sha256 tx)))
+(define-read-only (SHA-256d (data (buff 1024)))
+  (sha256 (sha256 data)))
 
 ;; Get the txid of a transaction.
 ;; This is what you see on block explorers.
 (define-read-only (get-txid (tx (buff 1024)))
-    (reverse-buff32 (get-reversed-txid tx)))
+    (reverse-buff32 (SHA-256d tx)))
 
 ;; Determine if the ith bit in a uint is set to 1
 (define-read-only (is-bit-set (val uint) (bit uint))
-    (is-eq (mod (/ val (pow u2 bit)) u2) u1))
+  (> (bit-and val (bit-shift-left u1 bit)) u0))
 
 ;; Verify the next step of a Merkle proof.
 ;; This hashes cur-hash against the ctr-th hash in proof-hashes, and uses that as the next cur-hash.
@@ -319,7 +305,7 @@
 
                   (h1 (if is-left (unwrap-panic (element-at proof-hashes ctr)) cur-hash))
                   (h2 (if is-left cur-hash (unwrap-panic (element-at proof-hashes ctr))))
-                  (next-hash (sha256 (sha256 (concat h1 h2))))
+                  (next-hash (SHA-256d (concat h1 h2)))
                   (is-verified (and (is-eq (+ u1 ctr) (len proof-hashes)) (is-eq next-hash root-hash))))
              (merge state { cur-hash: next-hash, verified: is-verified})))))
 
@@ -364,7 +350,7 @@
 ;; Returns (err ERR-PROOF-TOO-SHORT) if the proof doesn't contain enough intermediate hash nodes in the merkle tree.
 
 (define-read-only (was-tx-mined-compact (height uint) (tx (buff 1024)) (header (buff 80)) (proof { tx-index: uint, hashes: (list 14 (buff 32)), tree-depth: uint}))
-    (let ((block (try! (parse-block-header header))))
+    (let ((block (unwrap! (parse-block-header header) (err ERR-BAD-HEADER))))
       (was-tx-mined-internal height tx header (get merkle-root block) proof)))
 
 (define-read-only (was-tx-mined (height uint) (tx (buff 1024)) (header { version: (buff 4), parent: (buff 32), merkle-root: (buff 32), timestamp: (buff 4), nbits: (buff 4), nonce: (buff 4) }) (proof { tx-index: uint, hashes: (list 14 (buff 32)), tree-depth: uint}))
@@ -374,5 +360,5 @@
 ;; This function must only called with the merkle root of the provided header
 (define-private (was-tx-mined-internal (height uint) (tx (buff 1024)) (header (buff 80)) (merkle-root (buff 32)) (proof { tx-index: uint, hashes: (list 14 (buff 32)), tree-depth: uint}))
     (if (verify-block-header header height)
-        (verify-merkle-proof (get-reversed-txid tx) (reverse-buff32 merkle-root) proof)
+        (verify-merkle-proof (SHA-256d tx) (reverse-buff32 merkle-root) proof)
         (err u1)))

--- a/tests/clarity-bitcoin_parse_test.ts
+++ b/tests/clarity-bitcoin_parse_test.ts
@@ -124,7 +124,7 @@ Clarinet.test({
   name: "Ensure that bitcoin headers can be parsed",
   async fn(chain: Chain, accounts: Map<string, Account>) {
     const deployer = accounts.get("deployer")!;
-    const block = chain.mineBlock([
+    let block = chain.mineBlock([
       parseBlockHeader(
         hexToBytes(
           "000000203c437224480966081c2b14afac79e58207d996c8ac9d32000000000000000000847a4c2c77c8ecf0416ca07c2dc038414f14135017e18525f85cacdeedb54244e0d6b958df620218c626368a"
@@ -141,6 +141,24 @@ Clarinet.test({
       timestamp: 1488574176,
       nbits: 402809567,
       nonce: 2318804678,
+    });
+    block = chain.mineBlock([
+      parseBlockHeader(
+        hexToBytes(
+          "0020952c929316de1469df3abaff26835b0e73f45317f437b431e5e53a000000000000005c10dbda435580e08e54cd53f1504ee02a147a5d3e646a75131f9eff2e732492e838a56226d5461972717cf7"
+        ),
+        deployer
+      ),
+    ]);
+    expectHeaderObject(block, {
+      version: 747970560,
+      parent:
+        "000000000000003ae5e531b437f41753f4730e5b8326ffba3adf6914de169392",
+      merkleRoot:
+        "9224732eff9e1f13756a643e5d7a142ae04e50f153cd548ee0805543dadb105c",
+      timestamp: 1654995176,
+      nbits: 424072486,
+      nonce: 4152127858,
     });
   },
 });

--- a/tests/clarity-bitcoin_parse_test.ts
+++ b/tests/clarity-bitcoin_parse_test.ts
@@ -117,6 +117,64 @@ Clarinet.test({
         },
       ],
     });
+    block = chain.mineBlock([
+      parseTx(
+        "0x02000000019f9069891e7c64089afc0fd54b58c2044a8f61dc23d0b70abd8a1a4eee3bb36e010000006a47304402204c882028c0eb0dde2297fe3b5873abb2c0868938d63141705bb89025b08130b302204d0cd527a0ef4260ca95babc977f9e97ba41f947a4d16dba8dee823dcaff790e0121030c82347d355523ff0a4ee5c45d8dea6423e3b41d5aecaf1372af7596002ea49afdffffff0838180000000000001976a91400eb31b8bd6003f946887129468a16570b68845288ac38180000000000001976a914124d44a6ddbee55099615560ba8d7d53fc02257a88ac38180000000000001976a91481ee7e1dcb06cd261a26e6309117568f0b5d9f4988ac38180000000000001976a914973945b46e1548d4da32d96e5e09c8aa02103ff888ac38180000000000001976a914dbd958d812af104b5501d242c5cda84b3549382888ac38180000000000001976a914e03a8ffbc18b05583f804b68de97ab683705ec7f88ac10270000000000001976a9140b650f021ff2ae2165594ae51c7b1fa88f719e5f88ac8cf11800000000001976a9144e1f6f57aa65cc6d394e227b665335cf07f897a888ac95f92400",
+        deployer
+      ),
+    ]);
+
+    expectTxObject(block, {
+      version: 2,
+      locktime: 2423189,
+      ins: [
+        {
+          outpoint: {
+            hash: "6eb33bee4e1a8abd0ab7d023dc618f4a04c2584bd50ffc9a08647c1e8969909f",
+            index: 1,
+          },
+          scriptSig:
+            "47304402204c882028c0eb0dde2297fe3b5873abb2c0868938d63141705bb89025b08130b302204d0cd527a0ef4260ca95babc977f9e97ba41f947a4d16dba8dee823dcaff790e0121030c82347d355523ff0a4ee5c45d8dea6423e3b41d5aecaf1372af7596002ea49a",
+          sequence: 4294967293,
+        },
+      ],
+      outs: [
+        {
+          scriptPubKey:
+            "76a91400eb31b8bd6003f946887129468a16570b68845288ac",
+          value: 6200,
+        },
+        {
+          scriptPubKey: "76a914124d44a6ddbee55099615560ba8d7d53fc02257a88ac",
+          value: 6200,
+        },
+        {
+          scriptPubKey: "76a91481ee7e1dcb06cd261a26e6309117568f0b5d9f4988ac",
+          value: 6200,
+        },
+        {
+          scriptPubKey: "76a914973945b46e1548d4da32d96e5e09c8aa02103ff888ac",
+          value: 6200,
+        },
+        {
+          scriptPubKey: "76a914dbd958d812af104b5501d242c5cda84b3549382888ac",
+          value: 6200,
+        },
+        {
+          scriptPubKey: "76a914e03a8ffbc18b05583f804b68de97ab683705ec7f88ac",
+          value: 6200,
+        },
+        {
+          scriptPubKey: "76a9140b650f021ff2ae2165594ae51c7b1fa88f719e5f88ac",
+          value: 10000,
+        },
+        {
+          scriptPubKey: "76a9144e1f6f57aa65cc6d394e227b665335cf07f897a888ac",
+          value: 1634700,
+        },
+      ],
+    });
+
   },
 });
 

--- a/tests/clarity-bitcoin_test.ts
+++ b/tests/clarity-bitcoin_test.ts
@@ -381,3 +381,40 @@ Clarinet.test({
     block.receipts[0].result.expectErr().expectUint(Error.ERR_TOO_SHORT);
   },
 });
+
+Clarinet.test({
+  name: "Ensure is-bit-set determines if the bit in a uint is set to 1",
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    const deployer = accounts.get("deployer")!;
+    let block = chain.mineBlock([
+      Tx.contractCall("clarity-bitcoin","is-bit-set",[types.uint(10),types.uint(0)],deployer.address),
+      Tx.contractCall("clarity-bitcoin","is-bit-set",[types.uint(10),types.uint(1)],deployer.address),
+      Tx.contractCall("clarity-bitcoin","is-bit-set",[types.uint(51),types.uint(2)],deployer.address),
+      Tx.contractCall("clarity-bitcoin","is-bit-set",[types.uint(51),types.uint(3)],deployer.address),
+      Tx.contractCall("clarity-bitcoin","is-bit-set",[types.uint(255),types.uint(7)],deployer.address),
+      Tx.contractCall("clarity-bitcoin","is-bit-set",[types.uint(0),types.uint(0)],deployer.address),
+      Tx.contractCall("clarity-bitcoin","is-bit-set",[types.uint(255),types.uint(0)],deployer.address),
+      Tx.contractCall("clarity-bitcoin","is-bit-set",[types.uint(255),types.uint(7)],deployer.address),
+      Tx.contractCall("clarity-bitcoin","is-bit-set",[types.uint(128),types.uint(7)],deployer.address),
+      Tx.contractCall("clarity-bitcoin","is-bit-set",[types.uint(240),types.uint(4)],deployer.address),
+      Tx.contractCall("clarity-bitcoin","is-bit-set",[types.uint(42),types.uint(2)],deployer.address),
+      Tx.contractCall("clarity-bitcoin","is-bit-set",[types.uint(255),types.uint(8)],deployer.address),
+      Tx.contractCall("clarity-bitcoin","is-bit-set",[types.uint(1),types.uint(1)],deployer.address),
+      Tx.contractCall("clarity-bitcoin","is-bit-set",[types.uint(1),types.uint(0)],deployer.address),
+    ]);
+    block.receipts[0].result.expectBool(false);
+    block.receipts[1].result.expectBool(true);
+    block.receipts[2].result.expectBool(false);
+    block.receipts[3].result.expectBool(false);
+    block.receipts[4].result.expectBool(true);
+    block.receipts[5].result.expectBool(false);
+    block.receipts[6].result.expectBool(true);
+    block.receipts[7].result.expectBool(true);
+    block.receipts[8].result.expectBool(true);
+    block.receipts[9].result.expectBool(true);
+    block.receipts[10].result.expectBool(false);
+    block.receipts[11].result.expectBool(false);
+    block.receipts[12].result.expectBool(false);
+    block.receipts[13].result.expectBool(true);
+  },
+});


### PR DESCRIPTION
Mostly optimizations:

- Removed `read-slice` function because it's just a wrapper for `slice?`
- Removed variables only used once in `read-uint` functions, `read-hashslice`, `read-varslice`, `inner-reverse`
- Added variables to reduce `get` calls in `read-hashslice` and `read-varslice`
- removed dead-code in `parse-block-header`. `as-max-len?` would never throw the second branch because  the buffer parameter will always have a length shorter than 80.
- renamed `get-reverse-txid` to SHA-256d to re-use the function in places where sha256 was called 2 times. also it describes the actual logic inside the function
- `is-bit-set` uses bit-wise functions, added tests